### PR TITLE
Fix renovate bot error that json is invalid

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "reviewers": [
         "RolandMacDoland",
         "Doomsk",
-	"pimvenderbosch"
+        "pimvenderbosch"
     ],
     "labels": [
         "renovate"

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
 	"pimvenderbosch"
     ],
     "labels": [
-        "renovate",
+        "renovate"
     ],
     "ignoreDeps": [
     ]


### PR DESCRIPTION
Renovate bot seems to be incorrectly configured, see #21 . There is an error that the json data is not valid.